### PR TITLE
feat: Add option to reply text detected in an image

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -268,6 +268,15 @@ class _HomePageState extends State<HomePage> {
                         elevation: 5.0,
                       ),
                       new RaisedButton(
+                        onPressed: () {
+                          _speakOCR(text);
+                        },
+                        padding: const EdgeInsets.all(10.0),
+                        child: const Text('Replay'),
+                        color: Color(0xFFE08284),
+                        elevation: 5.0,
+                      ),
+                      new RaisedButton(
                         onPressed: _stopTts,
                         padding: const EdgeInsets.all(10.0),
                         child: const Text('Stop'),


### PR DESCRIPTION
Fix #6 

Add a replay button to the OCR dialog to allow users to listen to the text detected repeatedly if needed. 