### PR TITLE
fix: Add a dialog view for currency detection

### DIFF
--- a/lib/currency_detection/currency.dart
+++ b/lib/currency_detection/currency.dart
@@ -77,13 +77,6 @@ class CurrPage {
                         color: Color(0xFFE08284),
                         elevation: 5.0,
                       ),
-                      new RaisedButton(
-                        onPressed: _stopTts,
-                        padding: const EdgeInsets.all(10.0),
-                        child: const Text('Stop'),
-                        color: Color(0xFFE08284),
-                        elevation: 5.0,
-                      ),
                       new Image.file(picture),
                       SizedBox(width: 20),
                       new Text("$text"),

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -111,7 +111,7 @@ class _HomePageState extends State<HomePage> {
                           highlightColor: Hexcolor('#A8DEE0'),
                           splashColor: Hexcolor('#F9E2AE'),
                           onPressed: () => getCapImage(),
-                          child: Text("Feature: Image Captioning",
+                          child: Text("Image Captioning",
                               style: TextStyle(
                                   fontSize: 27.0,
                                   color: Colors.white,
@@ -137,7 +137,7 @@ class _HomePageState extends State<HomePage> {
                           highlightColor: Hexcolor('#F9E2E'),
                           splashColor: Hexcolor('#FBC78D'),
                           onPressed: () => getCurrImage(),
-                          child: Text("Feature: Currency Identifier",
+                          child: Text("Currency Identifier",
                               style: TextStyle(
                                   fontSize: 27.0,
                                   color: Colors.white,
@@ -150,7 +150,7 @@ class _HomePageState extends State<HomePage> {
                           highlightColor: Colors.yellow[900],
                           splashColor: Colors.yellow[500],
                           onPressed: () => _speak(),
-                          child: Text("Feature: Fruits & Vegetable Identifier",
+                          child: Text("Fruits & Vegetable Identifier",
                               style: TextStyle(
                                   fontSize: 27.0,
                                   color: Colors.white,
@@ -314,7 +314,7 @@ class _HomePageState extends State<HomePage> {
     } else if (a == 1) {
       await flutterTts.speak("Image Captioning");
     } else if (a == 2) {
-      await flutterTts.speak("Text Extraction");
+      await flutterTts.speak("Text Extraction from images");
     } else if (a == 3) {
       await flutterTts.speak("Currency Identifier");
     }

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -43,8 +43,7 @@ class _HomePageState extends State<HomePage> {
       _currImage = currImage;
     });
     if (currImage != null) {
-      Navigator.of(context).push(MaterialPageRoute(
-          builder: (context) => CurrPage(currImage: currImage)));
+      CurrPage.currencyDetect(context, currImage);
     }
   }
 


### PR DESCRIPTION
Fix #7  

Shift over from a new screen to a dialog view for currency identification for easier navigation. A user will have to press a back button to exit a screen, whereas a dialog can just be dismissed with a tap on the device screen. 

<img src="https://cdn.discordapp.com/attachments/757812296142815244/760442694031114301/Screenshot_2020-09-29-15-37-25-129_com.team4.helping_hands.jpg" width=250 height=500 align=center>